### PR TITLE
Set default expiration to 31 days instead of 28.

### DIFF
--- a/dnssec-reverb
+++ b/dnssec-reverb
@@ -21,6 +21,7 @@ DS_PARAM="-n -2"
 SERIAL_TAG="_SERIAL_"
 
 NOW=`date +%Y%m%d%H%M%S`
+EXPIRE=$(echo "`date +%s` + (31*24*60*60)" | bc)
 LOCKF=""
 
 Fatal()
@@ -135,7 +136,7 @@ sign()
 	done
 	cmdname=`basename $signzone`
 	[ "$KSS" != "" ] && KSS="$KEYDIR/$KSS"
-	$signzone $_SIGN_PARAM -o $ZONE -f "$ZONEFILE.signed" $ZONEFILE.tmp $KEYDIR/$ZSK $KEYDIR/$KSK $KSS
+	$signzone $_SIGN_PARAM -e $EXPIRE -o $ZONE -f "$ZONEFILE.signed" $ZONEFILE.tmp $KEYDIR/$ZSK $KEYDIR/$KSK $KSS
 	echo "signzone returns $?"
 	rm $ZONEFILE.tmp
 	eval $RELOAD_COMMAND


### PR DESCRIPTION
Define `EXPIRE` to be 31 days from now, and pass it as the `-e` arg of `$signzone` (`ldns-signzone`)

Without `-e`, ldns-signzone sets the expiration in 1 month ( 4 x week = 28 days ):

Ref (LDNS source):
- Constant:  https://www.nlnetlabs.nl/documentation/ldns/dnssec_8h.html#a565cc51b68d4b5723830434ee1c0dfe0
- Usage: https://www.nlnetlabs.nl/documentation/ldns/dnssec__sign_8c_source.html#l00084