### PR TITLE
Format EXPIRE based on whether we use bind or nsd

### DIFF
--- a/dnssec-reverb
+++ b/dnssec-reverb
@@ -21,7 +21,6 @@ DS_PARAM="-n -2"
 SERIAL_TAG="_SERIAL_"
 
 NOW=`date +%Y%m%d%H%M%S`
-EXPIRE=$(echo "`date +%s` + (31*24*60*60)" | bc)
 LOCKF=""
 
 Fatal()
@@ -45,6 +44,15 @@ else
 	Fatal "Can't find config file"
 fi
 . $CONF
+
+# bind - expire format: now +N seconds
+if [[ $signzone = *'dnssec-signzone' ]]; then
+  EXPIRE="+2678400"
+fi
+# nsd - expire format: timestamp
+if [[ $signzone = *'ldns-signzone' ]]; then
+  EXPIRE=$(echo "`date +%s` + (31*24*60*60)" | bc)
+fi
 
 # defaults
 [ "$MASTERDIR" = "" ] && Fatal "\$MASTERDIR not set"


### PR DESCRIPTION
Simple check, based on which command we specify in config.

Simply returns +2678400 ( 31 days) for bind, no calculations are necessary ATM

References:

From `ldns-signzone` man page:
> -e date
>     Set expiration date of the signatures to this date, the format can be YYYYMMDD[hhmmss], or a **timestamp**.

From Bind's `dnssec-signzone` man page:
> -e end-time
Specify the date and time when the generated RRSIG records expire. As with start-time, an absolute time is indicated in YYYYMMDDHHMMSS notation. A time relative to the start time is indicated with +N, which is N seconds from the start time. A time relative to the current time is indicated with now+N. If no end-time is specified, 30 days from the start time is used as a default. end-time must be later than start-time.

`dnssec-signzone`'s start date is current date -1 hour if not specified.
