### PR TITLE
Introduce EXPIRE_DAYS configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Path:
 * control: nsd-control path (/usr/sbin/nsd-control)
 * RELOAD_COMMAND: reload command ($checkzone \$ZONE \$ZONE || exit 1; $control reload && $control notify)
 
+Signatures expiration:
+* EXPIRE_DAYS: used to calculate the expiration date of the signatures to this date. Defaults to 33.
+
 Params:
 * KSK_PARAM: keygen's options for KSK (-a ECDSAP256SHA256 -k)
 * ZSK_PARAM: keygen's options for ZSK (-a ECDSAP256SHA256)

--- a/dnssec-reverb
+++ b/dnssec-reverb
@@ -19,8 +19,8 @@ ZSK_PARAM="-a ECDSAP256SHA256 "
 SIGN_PARAM="-n"
 DS_PARAM="-n -2"
 SERIAL_TAG="_SERIAL_"
-
 NOW=`date +%Y%m%d%H%M%S`
+DEFAULT_EXPIRE=33
 LOCKF=""
 
 Fatal()
@@ -47,11 +47,11 @@ fi
 
 # bind - expire format: now +N seconds
 if [[ $signzone = *'dnssec-signzone' ]]; then
-  EXPIRE="+2678400"
+  EXPIRE=$(echo "+`echo "(${EXPIRE_DAYS:-$DEFAULT_EXPIRE}*24*60*60)" | bc`")
 fi
 # nsd - expire format: timestamp
 if [[ $signzone = *'ldns-signzone' ]]; then
-  EXPIRE=$(echo "`date +%s` + (31*24*60*60)" | bc)
+  EXPIRE=$(echo "`date +%s` + (${EXPIRE_DAYS:-$DEFAULT_EXPIRE}*24*60*60)" | bc)
 fi
 
 # defaults


### PR DESCRIPTION
EXPIRE_DAYS can be set in the configuration file. It is used to calculate the expiration date of the signatures.
Defaults to 33 days if not defined in config.

Related to #8 