### PR TITLE
fix erroneous KEYZONE_CMD Fatal text

### DIFF
--- a/dnssec-reverb
+++ b/dnssec-reverb
@@ -57,7 +57,7 @@ fi
 
 # defaults
 DNS_TOOL=${DNS_TOOL:-nsd}
-[ "$KEYGEN_CMD" = "" ] && Fatal "cannot find \$KEYZONE_CMD"
+[ "$KEYGEN_CMD" = "" ] && Fatal "cannot find \$KEYGEN_CMD"
 [ "$SIGNZONE_CMD" = "" ] && Fatal "cannot find \$SIGNZONE_CMD"
 [ "$KEY2DS_CMD" = "" ] && Fatal "cannot find \$KEY2DS_CMD"
 [ "$CHECKZONE_CMD" = "" ] && Fatal "cannot find \$CHECKZONE_CMD"


### PR DESCRIPTION
Had a confusing moment of trying to find `KEYZONE_CMD` before realizing it was supposed to be `KEYGEN_CMD` in the error text.